### PR TITLE
Debug two posts title missing

### DIFF
--- a/_posts/2019-12-31-At the End of Two Thousand and Nineteen.md
+++ b/_posts/2019-12-31-At the End of Two Thousand and Nineteen.md
@@ -2,8 +2,8 @@
 layout: post 
 title: "At the End of Two Thousand and Nineteen" 
 date: 2019-12-31 23:59:59
-categories: [Life? What life?]
-tags: [life]
+categories: ["Life? What Life?"]
+tags: [life, read, movie, game]
 ---
 
 每到写年终总结的时候才会反省这一年又没做什么。

--- a/_posts/2020-01-01-New-Year-Resolution-2020.md
+++ b/_posts/2020-01-01-New-Year-Resolution-2020.md
@@ -2,7 +2,7 @@
 layout: post
 title: "2020 New Year Resolution"
 date: 2020-01-01 13:09
-categories: [Life? What Life?]
+categories: ["Life? What Life?"]
 tags: [to-do]
 ---
 


### PR DESCRIPTION
- Add double quotation marks to category. Otherwise, it would result in errors in page display.